### PR TITLE
Rename HoriHD to HorizonHD

### DIFF
--- a/WindowsFormsApp1 - Copy/Form1.Designer.cs
+++ b/WindowsFormsApp1 - Copy/Form1.Designer.cs
@@ -28,7 +28,7 @@
             this.Wii3DS_radio_3DS = new System.Windows.Forms.RadioButton();
             this.Wii3DS_radio_Wii = new System.Windows.Forms.RadioButton();
             this.ds_vf_standard = new System.Windows.Forms.RadioButton();
-            this.ds_vf_horihd = new System.Windows.Forms.RadioButton();
+            this.ds_vf_horizonhd = new System.Windows.Forms.RadioButton();
             this.ds_vf_3d = new System.Windows.Forms.RadioButton();
             this.ds_3dformat_leftright = new System.Windows.Forms.RadioButton();
             this.ds_3dformat_updown = new System.Windows.Forms.RadioButton();
@@ -139,17 +139,17 @@
             this.ds_vf_standard.UseVisualStyleBackColor = true;
             this.ds_vf_standard.CheckedChanged += new System.EventHandler(this.test);
             // 
-            // ds_vf_horihd
+            // ds_vf_horizonhd
             // 
-            this.ds_vf_horihd.AutoSize = true;
-            this.ds_vf_horihd.Location = new System.Drawing.Point(0, 32);
-            this.ds_vf_horihd.Name = "ds_vf_horihd";
-            this.ds_vf_horihd.Size = new System.Drawing.Size(87, 17);
-            this.ds_vf_horihd.TabIndex = 3;
-            this.ds_vf_horihd.TabStop = true;
-            this.ds_vf_horihd.Text = "HoriHD 240p";
-            this.ds_vf_horihd.UseVisualStyleBackColor = true;
-            this.ds_vf_horihd.CheckedChanged += new System.EventHandler(this.ds_vf_horihd_CheckedChanged);
+            this.ds_vf_horizonhd.AutoSize = true;
+            this.ds_vf_horizonhd.Location = new System.Drawing.Point(0, 32);
+            this.ds_vf_horizonhd.Name = "ds_vf_horizonhd";
+            this.ds_vf_horizonhd.Size = new System.Drawing.Size(87, 17);
+            this.ds_vf_horizonhd.TabIndex = 3;
+            this.ds_vf_horizonhd.TabStop = true;
+            this.ds_vf_horizonhd.Text = "HorizonHD 240p";
+            this.ds_vf_horizonhd.UseVisualStyleBackColor = true;
+            this.ds_vf_horizonhd.CheckedChanged += new System.EventHandler(this.ds_vf_horizonhd_CheckedChanged);
             // 
             // ds_vf_3d
             // 
@@ -280,7 +280,7 @@
             // panel_ds_vf
             // 
             this.panel_ds_vf.Controls.Add(this.ds_vf_standard);
-            this.panel_ds_vf.Controls.Add(this.ds_vf_horihd);
+            this.panel_ds_vf.Controls.Add(this.ds_vf_horizonhd);
             this.panel_ds_vf.Controls.Add(this.ds_vf_3d);
             this.panel_ds_vf.Location = new System.Drawing.Point(32, 96);
             this.panel_ds_vf.Name = "panel_ds_vf";
@@ -872,7 +872,7 @@
         private System.Windows.Forms.RadioButton Wii3DS_radio_3DS;
         private System.Windows.Forms.RadioButton Wii3DS_radio_Wii;
         private System.Windows.Forms.RadioButton ds_vf_standard;
-        private System.Windows.Forms.RadioButton ds_vf_horihd;
+        private System.Windows.Forms.RadioButton ds_vf_horizonhd;
         private System.Windows.Forms.RadioButton ds_vf_3d;
         private System.Windows.Forms.RadioButton ds_3dformat_leftright;
         private System.Windows.Forms.RadioButton ds_3dformat_updown;

--- a/WindowsFormsApp1 - Copy/Form1.cs
+++ b/WindowsFormsApp1 - Copy/Form1.cs
@@ -305,7 +305,7 @@ namespace WindowsFormsApp1 {
                             ds_outputtype = 0;
                             vstup2 = vstup;
                             break;
-                        case "ds_vf_horihd":
+                        case "ds_vf_horizonhd":
                             vstup2 = vstup;
                             ds_outputtype = 1;
                             break;
@@ -361,7 +361,7 @@ namespace WindowsFormsApp1 {
                             goto skipaa;
                         }
                     }
-                    if(DS_VF.Name == "ds_vf_3d" || DS_VF.Name == "ds_vf_horihd") {
+                    if(DS_VF.Name == "ds_vf_3d" || DS_VF.Name == "ds_vf_horizonhd") {
                         if(codec == "libx264 ") {
                             if(max_bitrate > 2000) {
                                 bitrate = 2000;
@@ -798,7 +798,7 @@ namespace WindowsFormsApp1 {
             ds3dshow();
         }
 
-        private void ds_vf_horihd_CheckedChanged(object sender, EventArgs e) {
+        private void ds_vf_horizonhd_CheckedChanged(object sender, EventArgs e) {
             ds3dshow();
         }
         private void test(object sender, EventArgs e) {

--- a/WindowsFormsApp1/Form1.Designer.cs
+++ b/WindowsFormsApp1/Form1.Designer.cs
@@ -28,7 +28,7 @@
             this.Wii3DS_radio_3DS = new System.Windows.Forms.RadioButton();
             this.Wii3DS_radio_Wii = new System.Windows.Forms.RadioButton();
             this.ds_vf_standard = new System.Windows.Forms.RadioButton();
-            this.ds_vf_horihd = new System.Windows.Forms.RadioButton();
+            this.ds_vf_horizonhd = new System.Windows.Forms.RadioButton();
             this.ds_vf_3d = new System.Windows.Forms.RadioButton();
             this.ds_3dformat_leftright = new System.Windows.Forms.RadioButton();
             this.ds_3dformat_updown = new System.Windows.Forms.RadioButton();
@@ -141,17 +141,17 @@
             this.ds_vf_standard.UseVisualStyleBackColor = true;
             this.ds_vf_standard.CheckedChanged += new System.EventHandler(this.test);
             // 
-            // ds_vf_horihd
+            // ds_vf_horizonhd
             // 
-            this.ds_vf_horihd.AutoSize = true;
-            this.ds_vf_horihd.Location = new System.Drawing.Point(0, 32);
-            this.ds_vf_horihd.Name = "ds_vf_horihd";
-            this.ds_vf_horihd.Size = new System.Drawing.Size(87, 17);
-            this.ds_vf_horihd.TabIndex = 3;
-            this.ds_vf_horihd.TabStop = true;
-            this.ds_vf_horihd.Text = "HoriHD 240p";
-            this.ds_vf_horihd.UseVisualStyleBackColor = true;
-            this.ds_vf_horihd.CheckedChanged += new System.EventHandler(this.ds_vf_horihd_CheckedChanged);
+            this.ds_vf_horizonhd.AutoSize = true;
+            this.ds_vf_horizonhd.Location = new System.Drawing.Point(0, 32);
+            this.ds_vf_horizonhd.Name = "ds_vf_horizonhd";
+            this.ds_vf_horizonhd.Size = new System.Drawing.Size(87, 17);
+            this.ds_vf_horizonhd.TabIndex = 3;
+            this.ds_vf_horizonhd.TabStop = true;
+            this.ds_vf_horizonhd.Text = "HorizonHD 240p";
+            this.ds_vf_horizonhd.UseVisualStyleBackColor = true;
+            this.ds_vf_horizonhd.CheckedChanged += new System.EventHandler(this.ds_vf_horizonhd_CheckedChanged);
             // 
             // ds_vf_3d
             // 
@@ -282,7 +282,7 @@
             // panel_ds_vf
             // 
             this.panel_ds_vf.Controls.Add(this.ds_vf_standard);
-            this.panel_ds_vf.Controls.Add(this.ds_vf_horihd);
+            this.panel_ds_vf.Controls.Add(this.ds_vf_horizonhd);
             this.panel_ds_vf.Controls.Add(this.ds_vf_3d);
             this.panel_ds_vf.Location = new System.Drawing.Point(32, 96);
             this.panel_ds_vf.Name = "panel_ds_vf";
@@ -893,7 +893,7 @@
         private System.Windows.Forms.RadioButton Wii3DS_radio_3DS;
         private System.Windows.Forms.RadioButton Wii3DS_radio_Wii;
         private System.Windows.Forms.RadioButton ds_vf_standard;
-        private System.Windows.Forms.RadioButton ds_vf_horihd;
+        private System.Windows.Forms.RadioButton ds_vf_horizonhd;
         private System.Windows.Forms.RadioButton ds_vf_3d;
         private System.Windows.Forms.RadioButton ds_3dformat_leftright;
         private System.Windows.Forms.RadioButton ds_3dformat_updown;

--- a/WindowsFormsApp1/Form1.cs
+++ b/WindowsFormsApp1/Form1.cs
@@ -325,7 +325,7 @@ namespace WindowsFormsApp1 {
                             ds_outputtype = 0;
                             vstup2 = vstup;
                             break;
-                        case "ds_vf_horihd":
+                        case "ds_vf_horizonhd":
                             vstup2 = vstup;
                             ds_outputtype = 1;
                             break;
@@ -381,7 +381,7 @@ namespace WindowsFormsApp1 {
                             goto skipaa;
                         }
                     }
-                    if(DS_VF.Name == "ds_vf_3d" || DS_VF.Name == "ds_vf_horihd") {
+                    if(DS_VF.Name == "ds_vf_3d" || DS_VF.Name == "ds_vf_horizonhd") {
                         if(codec == "libx264 ") {
                             if(max_bitrate > 2000) {
                                 bitrate = 2000;
@@ -864,7 +864,7 @@ namespace WindowsFormsApp1 {
             ds3dshow();
         }
 
-        private void ds_vf_horihd_CheckedChanged(object sender, EventArgs e) {
+        private void ds_vf_horizonhd_CheckedChanged(object sender, EventArgs e) {
             ds3dshow();
         }
         private void test(object sender, EventArgs e) {


### PR DESCRIPTION
HoriHD was a name I came up with a while back, and I've decided to rename it to HorizonHD 6 months ago.
HorizonHD is a new name based on both Nintendo 3DS & Switch's Horizon OS.